### PR TITLE
Fix for Django 18 and typo correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Refactored and cleaned up code for easier maintainability
 
 1) Install:
 
-    pip install git+https://github.com/jaylett/django-locking.git#egg=django-locking
+    pip install git+https://github.com/rcooke/django-locking.git#egg=django-locking
 
 2) Add locking to the list of INSTALLED_APPS in project settings file; you also need `django.contrib.staticfiles` (probably already there):
 

--- a/locking/admin.py
+++ b/locking/admin.py
@@ -181,7 +181,7 @@ class LockableAdminMixin(object):
             msg = _(u"You own this lock for %s longer") %  until
             css_class = 'locking-edit'
         else:
-            msg = _(u"Locked by %s for %s longer") % (until, locked_by_name)
+            msg = _(u"Locked by %s for %s longer") % (locked_by_name, until)
             css_class = 'locking-locked'
 
         return (

--- a/locking/admin.py
+++ b/locking/admin.py
@@ -46,7 +46,9 @@ class LockableAdminMixin(object):
 
     def locking_media(self, obj=None):
         opts = self.model._meta
-        info = (opts.app_label, opts.module_name)
+# https://code.djangoproject.com/ticket/20853
+#        info = (opts.app_label, opts.module_name)
+        info = (opts.app_label, opts.model_name)
         pk = getattr(obj, 'pk', None) or 0
         return forms.Media(js=(
             reverse('admin:%s_%s_lock_js' % info, args=[pk]),))
@@ -74,7 +76,9 @@ class LockableAdminMixin(object):
             return functools.update_wrapper(wrapper, view)
 
         opts = self.model._meta
-        info = (opts.app_label, opts.module_name)
+# https://code.djangoproject.com/ticket/20853
+#        info = (opts.app_label, opts.module_name)
+        info = (opts.app_label, opts.model_name)
 
         urlpatterns = patterns('',
             url(r'^(.+)/locking_variables\.js$',

--- a/locking/admin.py
+++ b/locking/admin.py
@@ -205,3 +205,9 @@ class LockableAdminMixin(object):
 
 class LockableAdmin(LockableAdminMixin, admin.ModelAdmin):
     pass
+
+# Temporary for Diagnostics: (RCooke)
+from .models import Lock
+
+admin.site.register(Lock)
+

--- a/locking/migrations/0002_auto_20150706_1054.py
+++ b/locking/migrations/0002_auto_20150706_1054.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locking', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='lock',
+            name='_locked_by',
+            field=models.ForeignKey(related_name='working_on_locking_lock', db_column=b'locked_by', editable=False, to=settings.AUTH_USER_MODEL, null=True),
+        ),
+    ]

--- a/locking/models.py
+++ b/locking/models.py
@@ -286,3 +286,11 @@ class Lock(models.Model):
     def save(self, *vargs, **kwargs):
         super(Lock, self).save(*vargs, **kwargs)
         self._state.locking = False
+
+    # For debug logging and other diagnostics
+    def __unicode__(self):
+        try:
+            return "User %s for record '%s', pk=%s, status:%s type: %s, time left: %s"% (self.locked_by, self.content_type, self.object_id, self.is_locked, self.lock_type, self.lock_seconds_remaining)
+        except:
+            return "Lock object"
+

--- a/locking/models.py
+++ b/locking/models.py
@@ -18,7 +18,7 @@ from . import managers, settings as locking_settings
 from .utils import timedelta_to_seconds
 
 
-logger = logging.getLogger('django.locker')
+logger = logging.getLogger('project.lock_model')
 
 
 class ObjectLockedError(IOError):

--- a/locking/views.py
+++ b/locking/views.py
@@ -135,7 +135,7 @@ def locking_js(model_admin, request, object_id, extra_context=None):
         locking_urls.update({
             "lock": reverse("admin:%s_%s_lock" % info, args=[object_id]),
             "lock_clear":  reverse("admin:%s_%s_lock_clear" % info, args=[object_id]),
-            "lock_status": reverse("admin:%s_%s_lock_status" % info, args=[object_id]),        
+            "lock_status": reverse("admin:%s_%s_lock_status" % info, args=[object_id]),
         })
 
     js_vars = {

--- a/locking/views.py
+++ b/locking/views.py
@@ -15,6 +15,10 @@ from .models import Lock, ObjectLockedError
 from . import settings as locking_settings
 
 
+import logging
+logger = logging.getLogger('project.locking_view')
+
+
 json_encode = json.JSONEncoder(indent=4).encode
 
 

--- a/locking/views.py
+++ b/locking/views.py
@@ -119,7 +119,9 @@ def lock_status(model_admin, request, object_id, extra_context=None, **kwargs):
 
 def locking_js(model_admin, request, object_id, extra_context=None):
     opts = model_admin.model._meta
-    info = (opts.app_label, opts.module_name)
+# https://code.djangoproject.com/ticket/20853
+#        info = (opts.app_label, opts.module_name)
+    info = (opts.app_label, opts.model_name)
 
     locking_urls = {
         "lock_remove": reverse("admin:%s_%s_lock_remove" % info, args=[object_id]),


### PR DESCRIPTION
I'm creating this pull request just to bring two things to you attention:
- There is a typo here:  msg = _(u"Locked by %s for %s longer") % (until, locked_by_name)
- It should be:  msg = _(u"Locked by %s for %s longer") % (locked_by_name, until)
- I had to change some undocumented object names to get this to run under Django 18, as per:
  - https://code.djangoproject.com/ticket/20853
